### PR TITLE
Fix tcp output byte conversion

### DIFF
--- a/dnstap_receiver/outputs/output_tcp.py
+++ b/dnstap_receiver/outputs/output_tcp.py
@@ -36,8 +36,8 @@ async def plaintext_tcpclient(output_cfg, queue):
         # convert dnstap message
         msg = transform.convert_dnstap(fmt=output_cfg["format"], tapmsg=tapmsg)
             
-        # add delimiter
-        tcp_writer.write( b"%s%s" % (msg, output_cfg["delimiter"]) )
+        # write & add delimiter
+        tcp_writer.write(msg + output_cfg["delimiter"].encode())
         
         # connection lost ? exit and try to reconnect 
         if tcp_writer.transport._conn_lost:


### PR DESCRIPTION
While running tcp output you encouter the following trace.

::

    tcp_writer.write( b"%s%s" % (msg, output_cfg["delimiter"]) )
    TypeError: %b requires a bytes-like object, or an object that implements __bytes__, not 'str'

Parsing of sent messages looks good on a splunk server (Same parser used for
pdns-protobuf-receiver)