### PR TITLE
input_sniffer: Drop "bytes" key

### DIFF
--- a/dnstap_receiver/inputs/input_sniffer.py
+++ b/dnstap_receiver/inputs/input_sniffer.py
@@ -212,7 +212,6 @@ async def watch_buffer(cfg, q, queues_list, stats, cache):
             qhash = hashlib.sha1(hash_payload.encode()).hexdigest()
             if qhash in cache: tap["latency"] = round(tap["timestamp"]-cache[qhash],3)
           
-        tap["bytes"] = dns_payload
         tap["length"] = len(dns_payload)
         
         tap["rcode"] = dns_rcodes.RCODES[int.from_bytes(dns_payload[2:4], "big") & 15]


### PR DESCRIPTION
Since 9e95407 (new dnstap output, 2020-12-30) the sniffer input has had
the payload in the "payload" key to match the dnstap output, meaning
that the "bytes" key is just duplicate data now.

This fixes a bug where the sniffer input cannot be used with either a
JSON or YAML format output, since the transform function doesn't remove
the "bytes" key.