### PR TITLE
Remove loop parameter which was removed in Python 3.10

### DIFF
--- a/dnstap_receiver/inputs/input_socket.py
+++ b/dnstap_receiver/inputs/input_socket.py
@@ -135,7 +135,7 @@ def start_tcpsocket(cfg, queues_list, stats, geoip_reader, cache, start_shutdown
         
     clogger.debug("Input handler: listening on %s:%s" % (cfg_input["local-address"],cfg_input["local-port"])), 
     server = asyncio.start_server(cb_lambda, cfg_input["local-address"],cfg_input["local-port"],
-                                  ssl=ssl_context, loop=loop)
+                                  ssl=ssl_context)
     return server
     
 def start_unixsocket(cfg, queues_list, stats, geoip_reader, cache, start_shutdown):
@@ -149,6 +149,6 @@ def start_unixsocket(cfg, queues_list, stats, geoip_reader, cache, start_shutdow
     
     # asynchronous unix socket
     clogger.debug("Input handler: listening on %s" % cfg_input["path"])
-    server = asyncio.start_unix_server(cb_lambda, path=cfg_input["path"], loop=loop)
+    server = asyncio.start_unix_server(cb_lambda, path=cfg_input["path"])
                                                   
     return server


### PR DESCRIPTION
`start_unix_server` and `start_server` functions of asyncio had loop parameter deprecated since Python 3.8 and it was finally removed in Python 3.10, causing the application failure on start (see https://github.com/dmachard/python-dnstap-receiver/issues/105)

This parameter was never required and it's removal will not break any functionality.